### PR TITLE
Support for partial encoder freezing

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -107,6 +107,15 @@ Change input shape of the model:
     # if you set input channels not equal to 3, you have to set encoder_weights=None
     # how to handle such case with encoder_weights='imagenet' described in docs
     model = Unet('resnet34', input_shape=(None, None, 6), encoder_weights=None)
+    
+Freeze the backbone (encoder):
+
+.. code:: python
+    
+    # Freezes all encoder layers
+    model = Unet('resnet34', input_shape=(None, None, 6), encoder_freeze=True)
+    # Freezes just the first 80% of encoder layers
+    model = Unet('resnet34', input_shape=(None, None, 6), encoder_freeze=0.8)
    
 Simple training pipeline
 ~~~~~~~~~~~~~~~~~~~~~~~~

--- a/segmentation_models/models/_utils.py
+++ b/segmentation_models/models/_utils.py
@@ -1,10 +1,12 @@
 from keras_applications import get_submodules_from_kwargs
 
 
-def freeze_model(model, **kwargs):
-    """Set all layers non trainable, excluding BatchNormalization layers"""
+def freeze_model(model, fraction=1.0, **kwargs):
+    """Set layers non trainable, excluding BatchNormalization layers.
+       If a fraction is specified, only a fraction of the layers are
+       frozen (starting with the earliest layers)"""
     _, layers, _, _ = get_submodules_from_kwargs(kwargs)
-    for layer in model.layers:
+    for layer in model.layers[:int(len(model.layers) * fraction)]:
         if not isinstance(layer, layers.BatchNormalization):
             layer.trainable = False
     return

--- a/segmentation_models/models/fpn.py
+++ b/segmentation_models/models/fpn.py
@@ -199,7 +199,8 @@ def FPN(
         weights: optional, path to model weights.
         activation: name of one of ``keras.activations`` for last model layer (e.g. ``sigmoid``, ``softmax``, ``linear``).
         encoder_weights: one of ``None`` (random initialization), ``imagenet`` (pre-training on ImageNet).
-        encoder_freeze: if ``True`` set all layers of encoder (backbone model) as non-trainable.
+        encoder_freeze: if ``True`` set all layers of encoder (backbone model) as non-trainable. If a float, freezes
+                just that fraction of the encoder layers (starting with the earliest layers)
         encoder_features: a list of layer numbers or names starting from top of the model.
                 Each of these layers will be used to build features pyramid. If ``default`` is used
                 layer names are taken from ``DEFAULT_FEATURE_PYRAMID_LAYERS``.
@@ -245,7 +246,8 @@ def FPN(
 
     # lock encoder weights for fine-tuning
     if encoder_freeze:
-        freeze_model(backbone, **kwargs)
+        fraction = encoder_freeze if isinstance(encoder_freeze, float) else 1.0
+        freeze_model(backbone, fraction=fraction, **kwargs)
 
     # loading model weights
     if weights is not None:

--- a/segmentation_models/models/linknet.py
+++ b/segmentation_models/models/linknet.py
@@ -212,7 +212,8 @@ def Linknet(
             (e.g. ``sigmoid``, ``softmax``, ``linear``).
         weights: optional, path to model weights.
         encoder_weights: one of ``None`` (random initialization), ``imagenet`` (pre-training on ImageNet).
-        encoder_freeze: if ``True`` set all layers of encoder (backbone model) as non-trainable.
+        encoder_freeze: if ``True`` set all layers of encoder (backbone model) as non-trainable. If a float, freezes
+            just that fraction of the encoder layers (starting with the earliest layers)
         encoder_features: a list of layer numbers or names starting from top of the model.
                     Each of these layers will be concatenated with corresponding decoder block. If ``default`` is used
                     layer names are taken from ``DEFAULT_SKIP_CONNECTIONS``.
@@ -268,7 +269,8 @@ def Linknet(
 
     # lock encoder weights for fine-tuning
     if encoder_freeze:
-        freeze_model(backbone, **kwargs)
+        fraction = encoder_freeze if isinstance(encoder_freeze, float) else 1.0
+        freeze_model(backbone, fraction=fraction, **kwargs)
 
     # loading model weights
     if weights is not None:

--- a/segmentation_models/models/pspnet.py
+++ b/segmentation_models/models/pspnet.py
@@ -179,7 +179,8 @@ def PSPNet(
                 (e.g. ``sigmoid``, ``softmax``, ``linear``).
         weights: optional, path to model weights.
         encoder_weights: one of ``None`` (random initialization), ``imagenet`` (pre-training on ImageNet).
-        encoder_freeze: if ``True`` set all layers of encoder (backbone model) as non-trainable.
+        encoder_freeze: if ``True`` set all layers of encoder (backbone model) as non-trainable. If a float, freezes
+            just that fraction of the encoder layers (starting with the earliest layers)
         downsample_factor: one of 4, 8 and 16. Downsampling rate or in other words backbone depth
             to construct PSP module on it.
         psp_conv_filters: number of filters in ``Conv2D`` layer in each PSP block.

--- a/segmentation_models/models/unet.py
+++ b/segmentation_models/models/unet.py
@@ -186,7 +186,8 @@ def Unet(
             (e.g. ``sigmoid``, ``softmax``, ``linear``).
         weights: optional, path to model weights.
         encoder_weights: one of ``None`` (random initialization), ``imagenet`` (pre-training on ImageNet).
-        encoder_freeze: if ``True`` set all layers of encoder (backbone model) as non-trainable.
+        encoder_freeze: if ``True`` set all layers of encoder (backbone model) as non-trainable. If a float, freezes
+            just that fraction of the encoder layers (starting with the earliest layers)
         encoder_features: a list of layer numbers or names starting from top of the model.
             Each of these layers will be concatenated with corresponding decoder block. If ``default`` is used
             layer names are taken from ``DEFAULT_SKIP_CONNECTIONS``.
@@ -243,7 +244,8 @@ def Unet(
 
     # lock encoder weights for fine-tuning
     if encoder_freeze:
-        freeze_model(backbone, **kwargs)
+        fraction = encoder_freeze if isinstance(encoder_freeze, float) else 1.0
+        freeze_model(backbone, fraction=fraction, **kwargs)
 
     # loading model weights
     if weights is not None:


### PR DESCRIPTION
Allow you to freeze the backbone encoder partially. For example, you can set encoder_freeze=0.8 which will make the first 80% layers untrainable, and leave the last 20% trainable.

This lets you tune the trainability of your network.

I freeze early layers first because: early layers learn basic features that are less likely to change between data sets. Late layers learn abstract features that may change more between data sets.

In my experiment, setting a 95% freeze was good for accuracy AND training speed for Unet + inceptionv3.

# 0% frozen
python .\model.py --patience=10 --encoder_freeze_percent=0.0
Test accuracy: 90.0%. Epoch time: 60s

# 95% frozen
python .\model.py --patience=10 --encoder_freeze_percent=0.95
Test accuracy: 91.13%. Epoch time: 52s

# 100% frozen
python .\model.py --patience=10 --encoder_freeze_percent=1.0
Test accuracy: 91.00%. Epoch time: 50s
