### PR TITLE
Added hardcoded float32 for the activation layer

### DIFF
--- a/segmentation_models/models/unet.py
+++ b/segmentation_models/models/unet.py
@@ -147,7 +147,7 @@ def build_unet(
         kernel_initializer='glorot_uniform',
         name='final_conv',
     )(x)
-    x = layers.Activation(activation, name=activation)(x)
+    x = layers.Activation(activation, name=activation, dtype='float32')(x)
 
     # create keras model instance
     model = models.Model(input_, x)


### PR DESCRIPTION
Added hardcoding of `float32` for the activation layer. 

This will prevent overriding from the following call:
```
from tensorflow.keras import mixed_precision
mixed_precision.set_global_policy('mixed_float16')
```

This can help enable mixed precision training on Unet models